### PR TITLE
fix(patient): fix en fecha de nacimiento y de fallecimiento

### DIFF
--- a/src/lib/patient.ts
+++ b/src/lib/patient.ts
@@ -103,10 +103,10 @@ export function encode(patient) {
                 }],
             }],
             gender: genero, // male | female | other | unknown
-            birthDate: patient.fechaNacimiento ? patient.fechaNacimiento.toISOString().slice(0, 10) : null
+            birthDate: patient.fechaNacimiento ? typeof patient.fechaNacimiento === 'string' ? new Date(patient.fechaNacimiento).toISOString().slice(0, 10) : patient.fechaNacimiento.toISOString().slice(0, 10) : null
         };
         if (patient.fechaFallecimiento) {
-            pacienteFHIR.deceasedDateTime = patient.fechaFallecimiento.toISOString().slice(0, 10);
+            pacienteFHIR.deceasedDateTime = typeof patient.fechaFallecimiento === 'string' ? new Date(patient.fechaFallecimiento.toISOString().slice(0, 10)) : patient.fechaFallecimiento.toISOString().slice(0, 10);
         }
         if (patient.estadoCivil) {
             let estadoCivil;


### PR DESCRIPTION
Problema: Cuando el objeto paciente se consume vía API los compos de fecha son strings y el paquete de fhir no tomaba eso en cuenta. Ahora se realiza un control de type.